### PR TITLE
Unpolished demo migrations

### DIFF
--- a/demo/lorem-ipsum.html
+++ b/demo/lorem-ipsum.html
@@ -7,7 +7,7 @@
     Code distributed by Google as part of the polymer project is also
     subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
-<polymer-element name="lorem-ipsum" attributes="paragraphs">
+<dom-module name="lorem-ipsum" attributes="paragraphs">
 <script>
 
   (function() {
@@ -39,4 +39,4 @@
   })();
 
 </script>
-</polymer-element>
+</dom-module>

--- a/demo/sample-content.html
+++ b/demo/sample-content.html
@@ -11,7 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <template>
     <div id="content"></div>
   </template>
-</polymer-element>
+</dom-module>
 
 <script>
 


### PR DESCRIPTION
- Some demo codes have old 0.5 codes.
- For instance, polymer-elements is still used even it is deprecated.
