### PR TITLE
Fix font-size in the demos

### DIFF
--- a/demo/demo4.html
+++ b/demo/demo4.html
@@ -48,16 +48,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       };
     }
 
-    paper-toolbar {
+    paper-toolbar.tall {
       background-color: transparent;
     }
 
-    paper-toolbar .title {
+    paper-toolbar.tall .title {
       font-size: 40px;
       margin-left: 60px;
+
+      -webkit-transform-origin: left center;
+      transform-origin: left center;
+
+      /* Issue #15 */
+      isolation: isolate;
     }
 
-    paper-toolbar iron-icon {
+    paper-toolbar.tall iron-icon {
       margin: 0 8px;
     }
 
@@ -93,13 +99,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
 
     // custom transformation: scale header's title
-    var titleStyle = document.querySelector('.title').style;
+    var title = document.querySelector('.title');
     addEventListener('paper-header-transform', function(e) {
       var d = e.detail;
       var m = d.height - d.condensedHeight;
       var scale = Math.max(0.75, (m - d.y) / (m / 0.25)  + 0.75);
-      titleStyle.transform = titleStyle.webkitTransform =
-          'scale(' + scale + ') translateZ(0)';
+
+      Polymer.Base.transform('scale(' + scale + ') translateZ(0)', title);
     });
 
   </script>

--- a/demo/demo5.html
+++ b/demo/demo5.html
@@ -47,16 +47,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       };
     }
 
-    paper-toolbar {
+    paper-toolbar.tall {
       background-color: transparent;
     }
 
-    paper-toolbar .title {
+    paper-toolbar.tall .title {
       font-size: 40px;
       margin-left: 60px;
+
+      -webkit-transform-origin: left center;
+      transform-origin: left center;
+
+      /* Issue #15 */
+      isolation: isolate;
     }
 
-    paper-toolbar iron-icon {
+    paper-toolbar.tall iron-icon {
       margin: 0 8px;
     }
 
@@ -92,13 +98,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
 
     // custom transformation: scale header's title
-    var titleStyle = document.querySelector('.title').style;
+    var title = document.querySelector('.title');
     addEventListener('paper-header-transform', function(e) {
       var d = e.detail;
       var m = d.height - d.condensedHeight;
       var scale = Math.max(0.75, (m - d.y) / (m / 0.25)  + 0.75);
-      titleStyle.transform = titleStyle.webkitTransform =
-          'scale(' + scale + ') translateZ(0)';
+
+      Polymer.Base.transform('scale(' + scale + ') translateZ(0)', title);
     });
 
   </script>

--- a/demo/demo6.html
+++ b/demo/demo6.html
@@ -47,18 +47,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       };
     }
 
-    paper-toolbar {
+    paper-toolbar.tall {
       /* custom toolbar height */
       height: 256px;
       background-color: transparent;
     }
 
-    paper-toolbar .title {
+    paper-toolbar.tall .title {
       font-size: 40px;
       margin-left: 60px;
+
+      -webkit-transform-origin: left center;
+      transform-origin: left center;
+
+      /* Issue #15 */
+      isolation: isolate;
     }
 
-    paper-toolbar iron-icon {
+    paper-toolbar.tall iron-icon {
       margin: 0 8px;
     }
 
@@ -75,7 +81,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        we want to set the condensed header's height to be 64px. -->
   <paper-scroll-header-panel condenses header-height="256" condensed-header-height="64">
 
-    <paper-toolbar>
+    <paper-toolbar class="tall">
 
       <paper-icon-button icon="arrow-back"></paper-icon-button>
       <div class="flex"></div>
@@ -96,14 +102,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
 
     // custom transformation: scale header's title
-    var titleStyle = document.querySelector('.title').style;
+    var title = document.querySelector('.title');
     addEventListener('paper-header-transform', function(e) {
       var d = e.detail;
       var m = d.height - d.condensedHeight;
       var scale = Math.max(0.75, (m - d.y) / (m / 0.25)  + 0.75);
 
-      titleStyle.transform = titleStyle.webkitTransform =
-          'scale(' + scale + ') translateZ(0)';
+      Polymer.Base.transform('scale(' + scale + ') translateZ(0)', title);
     });
 
   </script>

--- a/demo/demo7.html
+++ b/demo/demo7.html
@@ -48,13 +48,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       };
     }
 
-    paper-toolbar {
+    paper-toolbar.tall {
       background-color: transparent;
     }
 
-    paper-toolbar .title {
+    paper-toolbar.tall .title {
       font-size: 40px;
       margin-left: 60px;
+
+      -webkit-transform-origin: left center;
+      transform-origin: left center;
+
+      /* Issue #15 */
+      isolation: isolate;
     }
 
     .content {
@@ -99,13 +105,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     // custom transformation: scale header's title
-    var titleStyle = document.querySelector('.title').style;
+    var title = document.querySelector('.title');
     addEventListener('paper-header-transform', function(e) {
       var d = e.detail;
       var m = d.height - d.condensedHeight;
       var scale = Math.max(0.75, (m - d.y) / (m / 0.25)  + 0.75);
-      titleStyle.transform = titleStyle.webkitTransform =
-          'scale(' + scale + ') translateZ(0)';
+
+      Polymer.Base.transform('scale(' + scale + ') translateZ(0)', title);
     });
 
   </script>

--- a/demo/demo8.html
+++ b/demo/demo8.html
@@ -62,6 +62,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     .bottom-text {
       -webkit-transform: translateZ(0);
       transform: translateZ(0);
+
       font-size: 20px;
       padding-bottom: 10px;
     }

--- a/demo/demo9.html
+++ b/demo/demo9.html
@@ -61,14 +61,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       height: 40px;
     }
 
-    .field  iron-icon {
+    .field iron-icon {
       color: var(--google-grey-700);
       fill: var(--google-grey-700);
       margin: 0 8px;
     }
     
-    .field  paper-input {
-      height: 40px;
+    .field input {
+      font-size: 20px;
+      outline: 0;
+      border: none;
+      margin-left: 20px;
     }
 
     .content {
@@ -88,7 +91,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       
       <div class="flex center horizontal layout bottom field">
         <iron-icon icon="menu"></iron-icon>
-        <paper-input class="flex"></paper-input>
+        <input class="flex">
         <iron-icon icon="av:mic"></iron-icon>
       </div>
     </paper-toolbar>

--- a/demo/index.html
+++ b/demo/index.html
@@ -47,16 +47,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       };
     }
 
-    paper-toolbar {
+    paper-toolbar.tall {
       background-color: transparent;
     }
 
-    paper-toolbar .title {
+    paper-toolbar.tall .title {
       font-size: 40px;
       margin-left: 60px;
+
+      -webkit-transform-origin: left center;
+      transform-origin: left center;
+
+      /* Issue #15 */
+      isolation: isolate;
     }
 
-    paper-toolbar iron-icon {
+    paper-toolbar.tall iron-icon {
       margin: 0 8px;
     }
 
@@ -67,7 +73,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </style>
 
 </head>
-<body>
+<body unresolved>
 
   <paper-scroll-header-panel condenses>
 
@@ -92,13 +98,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
 
     // custom transformation: scale header's title
-    var titleStyle = document.querySelector('.title').style;
+    var title = document.querySelector('.title');
     addEventListener('paper-header-transform', function(e) {
       var d = e.detail;
       var m = d.height - d.condensedHeight;
       var scale = Math.max(0.75, (m - d.y) / (m / 0.25)  + 0.75);
-      titleStyle.transform = titleStyle.webkitTransform =
-          'scale(' + scale + ') translateZ(0)';
+
+      Polymer.Base.transform('scale(' + scale + ') translateZ(0)', title);
     });
 
   </script>


### PR DESCRIPTION
These changes will restore the `fon-size` in the paper-toolbar's title. The fix works only in shady until https://github.com/PolymerElements/paper-toolbar/issues/26 is resolved.
