### PR TITLE
Remove translateZ in #mainContainer

### DIFF
--- a/paper-scroll-header-panel.html
+++ b/paper-scroll-header-panel.html
@@ -95,9 +95,6 @@ To change the background for toolbar when it is condensed:
 
       overflow-x: hidden;
       overflow-y: auto;
-
-      -webkit-transform: translateZ(0);
-      transform: translateZ(0);
     }
 
     #headerContainer {


### PR DESCRIPTION
`translateZ` hides the scroller in Safari.  `translateZ` was added to fix https://github.com/Polymer/core-scroll-header-panel/issues/37;  however that issue was fixed in Chrome and it's now not necessary to prevent painting.

\cc @ebidel 
