### PR TITLE
remove "isolation: isolate" set on ".title"

### DIFF
--- a/demo/demo1.html
+++ b/demo/demo1.html
@@ -41,10 +41,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       background-color: var(--google-blue-500, #4285f4);
     }
 
-    paper-toolbar iron-icon {
-      margin: 0 8px;
-    }
-
     paper-toolbar .title {
       margin: 0 8px;
     }

--- a/demo/demo3.html
+++ b/demo/demo3.html
@@ -45,10 +45,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       background-color: transparent;
     }
 
-    paper-toolbar iron-icon {
-      margin: 0 8px;
-    }
-
     .content {
       padding: 8px;
     }

--- a/demo/demo4.html
+++ b/demo/demo4.html
@@ -58,13 +58,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       -webkit-transform-origin: left center;
       transform-origin: left center;
-
-      /* Issue #15 */
-      isolation: isolate;
-    }
-
-    paper-toolbar.tall iron-icon {
-      margin: 0 8px;
     }
 
     .content {

--- a/demo/demo5.html
+++ b/demo/demo5.html
@@ -57,13 +57,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       -webkit-transform-origin: left center;
       transform-origin: left center;
-
-      /* Issue #15 */
-      isolation: isolate;
-    }
-
-    paper-toolbar.tall iron-icon {
-      margin: 0 8px;
     }
 
     .content {

--- a/demo/demo6.html
+++ b/demo/demo6.html
@@ -59,13 +59,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       -webkit-transform-origin: left center;
       transform-origin: left center;
-
-      /* Issue #15 */
-      isolation: isolate;
-    }
-
-    paper-toolbar.tall iron-icon {
-      margin: 0 8px;
     }
 
     .content {

--- a/demo/demo7.html
+++ b/demo/demo7.html
@@ -58,9 +58,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       -webkit-transform-origin: left center;
       transform-origin: left center;
-
-      /* Issue #15 */
-      isolation: isolate;
     }
 
     .content {

--- a/demo/index.html
+++ b/demo/index.html
@@ -57,13 +57,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       -webkit-transform-origin: left center;
       transform-origin: left center;
-
-      /* Issue #15 */
-      isolation: isolate;
-    }
-
-    paper-toolbar.tall iron-icon {
-      margin: 0 8px;
     }
 
     .content {


### PR DESCRIPTION
Seems `isolation: isolate` set on `.title` is not needed anymore.  I tested on Chrome 43/44 and Canary and I verified the title was transformed correctly after removing `isolation: isolate`.  Also I removed some unused CSS.
