### PR TITLE
Move measurement code.

### DIFF
--- a/paper-scroll-header-panel.html
+++ b/paper-scroll-header-panel.html
@@ -295,7 +295,7 @@ Custom property | Description | Default
       'iron-resize': 'measureHeaderHeight'
     },
 
-    ready: function() {
+    attached: function() {
       this.async(this.measureHeaderHeight, 5);
       this._scrollHandler = this._scroll.bind(this);
       this.scroller.addEventListener('scroll', this._scrollHandler);

--- a/paper-scroll-header-panel.html
+++ b/paper-scroll-header-panel.html
@@ -301,7 +301,7 @@ Custom property | Description | Default
     },
 
     attached: function() {
-      this.async(this.measureHeaderHeight, 5);
+      this.async(this.measureHeaderHeight, 1);
     },
 
     /**

--- a/paper-scroll-header-panel.html
+++ b/paper-scroll-header-panel.html
@@ -295,10 +295,13 @@ Custom property | Description | Default
       'iron-resize': 'measureHeaderHeight'
     },
 
-    attached: function() {
-      this.async(this.measureHeaderHeight, 5);
+    ready: function() {
       this._scrollHandler = this._scroll.bind(this);
       this.scroller.addEventListener('scroll', this._scrollHandler);
+    },
+
+    attached: function() {
+      this.async(this.measureHeaderHeight, 5);
     },
 
     /**


### PR DESCRIPTION
Relying on attached rather than ready ensures all elements are on the page when we measure elements.  Particularly corrects IE11 issues where there wasn't enough space allowed for the header.
