### PR TITLE
Add possibility to customise #headerContainer

### DIFF
--- a/paper-scroll-header-panel.html
+++ b/paper-scroll-header-panel.html
@@ -66,6 +66,7 @@ Custom property | Description | Default
 --paper-scroll-header-panel-full-header | To change background for toolbar when it is at its full size | {}
 --paper-scroll-header-panel-condensed-header | To change the background for toolbar when it is condensed | {}
 --paper-scroll-header-container | To override or add container styles | {}
+--paper-scroll-header-container-header | To override or add header container styles | {}
 
 @group Paper Element
 @element paper-scroll-header-panel
@@ -113,6 +114,8 @@ Custom property | Description | Default
       top: 0;
       right: 0;
       left: 0;
+
+      @apply(--paper-scroll-header-container-header);
     }
 
     .bg-container {


### PR DESCRIPTION
Don't like the stuttering in `paper-scroll-header-container-header` but I can't think of any other meaningful name.
`--paper-scroll-header-container` could be renamed as well to `--paper-scroll-header-container-main` to keep consistency.
