### PR TITLE
Update paper-scroll-header-panel.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The following custom properties and mixins are available for styling:
 | --- | --- | --- |
 | --paper-scroll-header-panel-full-header | To change background for toolbar when it is at its full size | {} |
 | --paper-scroll-header-panel-condensed-header | To change the background for toolbar when it is condensed | {} |
-| --paper-scroll-header-container | To override or add container styles | {} |
+| --paper-scroll-header-panel-container | To override or add container styles | {}
+| --paper-scroll-header-panel-header-container | To override or add header styles | {}
 
 

--- a/paper-scroll-header-panel.html
+++ b/paper-scroll-header-panel.html
@@ -65,7 +65,8 @@ Custom property | Description | Default
 ----------------|-------------|----------
 --paper-scroll-header-panel-full-header | To change background for toolbar when it is at its full size | {}
 --paper-scroll-header-panel-condensed-header | To change the background for toolbar when it is condensed | {}
---paper-scroll-header-container | To override or add container styles | {}
+--paper-scroll-header-panel-container | To override or add container styles | {}
+--paper-scroll-header-panel-header-container | To override or add header styles | {}
 
 @group Paper Element
 @element paper-scroll-header-panel
@@ -104,8 +105,8 @@ Custom property | Description | Default
 
       overflow-x: hidden;
       overflow-y: auto;
-
-      @apply(--paper-scroll-header-container);
+      @apply(--paper-scroll-header-container); /* deprecated due to incorrect/confusing naming */
+      @apply(--paper-scroll-header-panel-container);
     }
 
     #headerContainer {
@@ -113,6 +114,7 @@ Custom property | Description | Default
       top: 0;
       right: 0;
       left: 0;
+      @apply(--paper-scroll-header-panel-header-container);
     }
 
     .bg-container {


### PR DESCRIPTION
No idea how this happened, but something ending in `header-container` seriously should apply to the `header-container`, not to the content of the page as well (which is a huge pain in combination with background color and cross fades).
