### PR TITLE
<dom-module> name attribute should be id

### DIFF
--- a/demo/lorem-ipsum.html
+++ b/demo/lorem-ipsum.html
@@ -7,7 +7,7 @@
     Code distributed by Google as part of the polymer project is also
     subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
-<dom-module name="lorem-ipsum" attributes="paragraphs">
+<dom-module id="lorem-ipsum" attributes="paragraphs">
 <script>
 
   (function() {


### PR DESCRIPTION
Noticed this while developing the linter.